### PR TITLE
Improve preflop demo and fix recommendation

### DIFF
--- a/display_preflop_methods.py
+++ b/display_preflop_methods.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python3
-"""Print a series of manual checks for `preflop.py`.
-
-This script exercises the public API of ``PreflopLookup`` along with helper
-functions. The goal is to make it easy to visually verify that range lookups
-and recommendations behave as expected.
-"""
+"""Show recommendations for a variety of preflop scenarios."""
 
 import os
 import sys
@@ -12,72 +7,49 @@ import sys
 # Ensure src package is on the path
 sys.path.append(os.path.join(os.path.dirname(__file__), "src", "llm_poker_solver"))
 
-from preflop import PreflopLookup, canonize_hand, expand_range
+from preflop import PreflopLookup
 
 
-# ---------------------------------------------------------------------------
-# helper printing functions
-# ---------------------------------------------------------------------------
-
-
-def run_get_ranges_tests(lookup: PreflopLookup) -> None:
-    """Print ranges for a variety of action sequences."""
+def main() -> None:
+    lookup = PreflopLookup()
 
     tests = [
-        ("UTG raise", None),
-        ("CO raise, BTN call", None),
-        ("CO raise, BTN call", "CO"),
-        ("CO raise, BTN 3bet", None),
-        ("CO raise, BTN 3bet", "CO"),
-        ("CO raise, BTN 3bet, CO call", "CO"),
-        ("BTN raise, SB 3bet, BTN 4bet", None),
-        ("BTN raise, SB 3bet, BTN 4bet", "SB"),
-    ]
-
-    print("=== get_ranges ===")
-    for action, hero in tests:
-        res = lookup.get_ranges(action, hero_position=hero)
-        print(f"Action: {action} | hero={hero or 'default'}")
-        print(f"  hero range   : {res.get('hero')}")
-        print(f"  villain range: {res.get('villain')}")
-        print("-" * 60)
-    print()
-
-
-def run_recommend_tests(lookup: PreflopLookup) -> None:
-    """Print recommended actions for specific hands."""
-
-    tests = [
+        ("UTG raise", "AhKs", "UTG"),
+        ("UTG raise", "7c7d", "UTG"),
         ("CO raise, BTN 3bet", "AhKs", None),
+        ("CO raise, BTN 3bet", "9c9d", None),
         ("CO raise, BTN 3bet", "AhKs", "CO"),
-        ("UTG raise, BTN 3bet", "9c9d", "UTG"),
+        ("CO raise, BTN 3bet", "9c9d", "CO"),
+        ("UTG raise, CO 3bet", "AhKs", "UTG"),
+        ("UTG raise, CO 3bet", "9c9d", "UTG"),
+        ("UTG raise, CO 3bet", "AhKs", "CO"),
+        ("UTG raise, CO 3bet", "9c9d", "CO"),
+        ("BTN raise, SB 3bet", "AhKs", "BTN"),
+        ("BTN raise, SB 3bet", "9c9d", "BTN"),
+        ("BTN raise, SB 3bet", "AhKs", "SB"),
+        ("BTN raise, SB 3bet", "9c9d", "SB"),
+        ("SB raise, BB 3bet", "AhKs", "SB"),
+        ("SB raise, BB 3bet", "9c9d", "SB"),
+        ("SB raise, BB 3bet", "AhKs", "BB"),
+        ("SB raise, BB 3bet", "9c9d", "BB"),
+        ("CO raise, BTN 3bet, CO 4bet", "AhKs", "CO"),
+        ("CO raise, BTN 3bet, CO 4bet", "9c9d", "CO"),
+        ("CO raise, BTN 3bet, CO 4bet", "AhKs", "BTN"),
+        ("UTG raise, CO 3bet, UTG 4bet", "AhKs", "UTG"),
+        ("UTG raise, CO 3bet, UTG 4bet", "9c9d", "UTG"),
+        ("UTG raise, CO 3bet, UTG 4bet", "AhKs", "CO"),
+        ("CO raise, BTN 3bet, CO 4bet, BTN allin", "AhKs", "CO"),
+        ("CO raise, BTN 3bet, CO 4bet, BTN allin", "9c9d", "CO"),
+        ("UTG raise, CO 3bet, UTG 4bet, CO allin", "AhKs", "UTG"),
+        ("UTG raise, CO 3bet, UTG 4bet, CO allin", "9c9d", "UTG"),
+        ("MP raise, CO call", "AhKs", "CO"),
+        ("CO raise, SB call", "7c6c", "SB"),
     ]
 
     print("=== recommend ===")
     for action, hand, hero in tests:
         rec = lookup.recommend(action, hand, hero_position=hero)
         print(f"Action: {action} | hand={hand} | hero={hero or 'default'} -> {rec}")
-    print()
-
-
-def run_utils_tests() -> None:
-    """Show helper function behaviour."""
-
-    print("=== expand_range ===")
-    for text in ["AQs+", "KTo+", "TT+"]:
-        print(f"{text}: {sorted(expand_range(text))}")
-
-    print("\n=== canonize_hand ===")
-    for hand in ["AhKs", "AdKd", "AsKd"]:
-        print(f"{hand} -> {canonize_hand(hand)}")
-    print()
-
-
-def main() -> None:
-    lookup = PreflopLookup()
-    run_get_ranges_tests(lookup)
-    run_recommend_tests(lookup)
-    run_utils_tests()
 
 
 if __name__ == "__main__":

--- a/src/llm_poker_solver/preflop.py
+++ b/src/llm_poker_solver/preflop.py
@@ -285,6 +285,7 @@ class PreflopLookup:
             hero_position = acts[-1][0]
         hero_position = hero_position.upper()
 
+        # find last action from the hero in the sequence
         hero_index = None
         for i in range(len(acts) - 1, -1, -1):
             if acts[i][0] == hero_position:
@@ -294,13 +295,42 @@ class PreflopLookup:
         if hero_index is None:
             raise ValueError("Hero position not found in action string")
 
-        scenario, hero_pos, _ = self._scenario_for_actions(acts[: hero_index + 1])
+        last_index = len(acts) - 1
         hand = canonize_hand(hero_hand)
 
-        call_range = self.chart.get_range_combos(scenario, hero_pos) or set()
-        alt_action = "3bet" if scenario.endswith("call") else "4bet"
-        alt_scenario = scenario.rsplit(", ", 1)[0] + f", {alt_action}"
-        raise_range = self.chart.get_range_combos(alt_scenario, hero_pos) or set()
+        def _scenario_with(act: str, idx: int) -> Tuple[str, str]:
+            tmp = acts[: idx + 1] + [(hero_position, act)]
+            scn, pos, _ = self._scenario_for_actions(tmp)
+            return scn, pos
+
+        call_range: Set[str] = set()
+        raise_range: Set[str] = set()
+
+        if hero_index == last_index:
+            # Hero was the last to act. Evaluate that action only.
+            scenario, hero_pos, _ = self._scenario_for_actions(acts[: hero_index + 1])
+            action_range = self.chart.get_range_combos(scenario, hero_pos) or set()
+
+            if acts[hero_index][1] == "call":
+                call_range = action_range
+            else:
+                raise_range = action_range
+        else:
+            # Villain acted most recently; hero must respond.
+            decision_index = last_index
+            villain_act = acts[decision_index][1]
+
+            call_scenario, hero_pos = _scenario_with("call", decision_index)
+            call_range = self.chart.get_range_combos(call_scenario, hero_pos) or set()
+
+            next_act = {"raise": "3bet", "3bet": "4bet", "4bet": "allin"}.get(
+                villain_act, None
+            )
+            if next_act is not None:
+                raise_scenario, raise_pos = _scenario_with(next_act, decision_index)
+                raise_range = (
+                    self.chart.get_range_combos(raise_scenario, raise_pos) or set()
+                )
 
         in_call = hand in call_range
         in_raise = hand in raise_range


### PR DESCRIPTION
## Summary
- simplify `display_preflop_methods.py` to print 30 recommendation scenarios
- adjust `PreflopLookup.recommend` logic so hero actions are evaluated correctly

## Testing
- `ruff check display_preflop_methods.py src/llm_poker_solver/preflop.py`
- `black --check display_preflop_methods.py src/llm_poker_solver/preflop.py`
- `python display_preflop_methods.py`