### PR TITLE
Add solver demo with bet size options

### DIFF
--- a/scripts/solver_demo.py
+++ b/scripts/solver_demo.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Interactive demo for TexasSolver with preflop ranges."""
+
+import os
+import sys
+import json
+import subprocess
+
+# add src package
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src', 'llm_poker_solver'))
+
+import preflop
+
+POSITION_FALLBACK = {
+    "EP": "UTG",
+    "MP": "LJ",
+}
+
+
+def _seat(pos: str) -> str:
+    return POSITION_FALLBACK.get(pos.upper(), pos.upper())
+
+
+def format_board(cards: str) -> str:
+    cards = cards.strip()
+    if len(cards) != 6:
+        raise ValueError("Board cards should be like 'QsJh2c'")
+    return f"{cards[0:2]},{cards[2:4]},{cards[4:6]}"
+
+
+def summarize_strategy(data: dict) -> None:
+    strat = data.get("strategy")
+    if not strat:
+        print("No strategy info found.")
+        return
+    actions = strat.get("actions", [])
+    combo_map = strat.get("strategy", {})
+    totals = [0.0] * len(actions)
+    count = 0
+    for probs in combo_map.values():
+        count += 1
+        for i, p in enumerate(probs):
+            totals[i] += p
+    if count:
+        print("\n=== Strategy Summary ===")
+        for act, val in zip(actions, totals):
+            print(f"{act}: {val / count:.3f}")
+
+
+def main() -> None:
+    lookup = preflop.PreflopLookup()
+
+    action = input("Enter preflop action (e.g. 'UTG raise, BTN call'): ").strip()
+    hero_position = input("Enter hero position (default last actor): ").strip() or None
+    flop = input("Enter flop cards (e.g. 'QsJh2c'): ").strip()
+
+    ranges = lookup.get_ranges(action, hero_position=hero_position)
+    hero_range = ranges.get("hero")
+    villain_range = ranges.get("villain")
+
+    print("\n=== Preflop ranges ===")
+    print(f"Hero: {hero_range}")
+    print(f"Villain: {villain_range}")
+
+    if not hero_range or not villain_range:
+        print("Could not determine ranges for both players.")
+        return
+
+    hero_combos = ",".join(sorted(preflop.expand_range(hero_range)))
+    villain_combos = ",".join(sorted(preflop.expand_range(villain_range)))
+
+    acts = preflop.parse_action_string(action)
+    if hero_position is None:
+        hero_position = acts[-1][0]
+    hero_index = next((i for i in range(len(acts) - 1, -1, -1) if acts[i][0].upper() == hero_position.upper()), len(acts) - 1)
+    villain_pos = acts[hero_index - 1][0] if hero_index == len(acts) - 1 and hero_index > 0 else acts[-1][0]
+
+    hero_seat = _seat(hero_position)
+    villain_seat = _seat(villain_pos)
+    hero_ip = preflop.POSTFLOP_ORDER.index(hero_seat) > preflop.POSTFLOP_ORDER.index(villain_seat)
+
+    ip_range = hero_combos if hero_ip else villain_combos
+    oop_range = villain_combos if hero_ip else hero_combos
+
+    board_text = format_board(flop)
+
+    bet_sizes = "25,33,50,66,75,100,150"
+    commands = [
+        "set_pot 100",
+        "set_effective_stack 200",
+        f"set_board {board_text}",
+        f"set_range_ip {ip_range}",
+        f"set_range_oop {oop_range}",
+        f"set_bet_sizes ip,flop,bet,{bet_sizes}",
+        f"set_bet_sizes oop,flop,bet,{bet_sizes}",
+        f"set_bet_sizes ip,flop,raise,{bet_sizes}",
+        f"set_bet_sizes oop,flop,raise,{bet_sizes}",
+        "set_bet_sizes ip,flop,allin",
+        "set_bet_sizes oop,flop,allin",
+        "build_tree",
+        "start_solve",
+        "dump_result result.json",
+    ]
+
+    print("\n=== TexasSolver commands ===")
+    for c in commands:
+        print(c)
+
+    solver_path = os.path.join("external", "TexasSolver", "build", "console_solver")
+    if os.path.exists(solver_path):
+        print("\nRunning solver...\n")
+        proc = subprocess.run([solver_path], input="\n".join(commands), text=True, capture_output=True)
+        print(proc.stdout)
+        if os.path.exists("result.json"):
+            with open("result.json") as f:
+                data = json.load(f)
+            summarize_strategy(data)
+    else:
+        print(f"Solver binary not found at {solver_path}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/llm_poker_solver/preflop.py
+++ b/src/llm_poker_solver/preflop.py
@@ -93,13 +93,13 @@ def expand_range(desc: str) -> Set[str]:
     for part in [p.strip() for p in desc.split(",")]:
         if not part:
             continue
-        if "-" in part and "+" not in part:
-            start, end = part.split("-")
-            hands.update(_expand_between(start.strip(), end.strip()))
-        elif part.endswith("+"):
+        if part.endswith("+"):
             hands.update(_expand_plus(part[:-1]))
         elif part.endswith("-"):
             hands.update(_expand_minus(part[:-1]))
+        elif "-" in part and "+" not in part:
+            start, end = part.split("-")
+            hands.update(_expand_between(start.strip(), end.strip()))
         else:
             hands.add(part)
     return hands
@@ -143,7 +143,9 @@ def _expand_minus(base: str) -> List[str]:
     prefix = base[0]
     suited = base[2] == "s"
     end = RANK_TO_INDEX[base[1]]
-    return [f"{prefix}{RANKS[i]}{'s' if suited else 'o'}" for i in range(2, end + 1)]
+    return [
+        f"{prefix}{RANKS[i]}{'s' if suited else 'o'}" for i in range(0, end + 1)
+    ]
 
 
 def canonize_hand(hand: str) -> str:
@@ -302,7 +304,7 @@ class PreflopLookup:
             hero_position = acts[-1][0]
         hero_position = hero_position.upper()
 
-        # find last action from the hero in the sequence
+        # locate the most recent action from the hero
         hero_index = None
         for i in range(len(acts) - 1, -1, -1):
             if acts[i][0] == hero_position:
@@ -312,53 +314,58 @@ class PreflopLookup:
         if hero_index is None:
             raise ValueError("Hero position not found in action string")
 
-        last_index = len(acts) - 1
         hand = canonize_hand(hero_hand)
 
-        # Helper to compute a scenario with an additional hero action
-        def _scenario_with(act: str) -> Tuple[str, str]:
-            tmp = acts[: last_index + 1] + [(hero_position, act)]
-            scn, pos, _ = self._scenario_for_actions(tmp)
-            return scn, pos
-
-        if hero_index == last_index:
-            # hero was the last to act, so analyse that action directly
-            scenario, hero_pos, _ = self._scenario_for_actions(acts[: hero_index + 1])
-            call_range = self.chart.get_range_combos(scenario, hero_pos) or set()
-
-            next_act = {
-                "call": "3bet",
-                "raise": "3bet",
-                "3bet": "4bet",
-                "4bet": "allin",
-            }.get(acts[hero_index][1], None)
-
-            if next_act is not None:
-                alt_scenario, alt_pos = _scenario_with(next_act)
-                raise_range = (
-                    self.chart.get_range_combos(alt_scenario, alt_pos) or set()
-                )
-            else:
-                raise_range = set()
+        # Determine the sequence prior to the hero's decision
+        if hero_index == len(acts) - 1:
+            pending = acts[:hero_index]
         else:
-            # villain acted after hero; hero decision pending
-            villain_act = acts[last_index][1]
-            call_scenario, hero_pos = _scenario_with("call")
-            call_range = self.chart.get_range_combos(call_scenario, hero_pos) or set()
+            pending = acts[:]
 
-            next_act = {
-                "raise": "3bet",
-                "3bet": "4bet",
-                "4bet": "allin",
-            }.get(villain_act, None)
+        villain_act = pending[-1][1] if pending else None
+        villain_pos = pending[-1][0] if pending else None
 
-            if next_act is not None:
-                raise_scenario, raise_pos = _scenario_with(next_act)
-                raise_range = (
-                    self.chart.get_range_combos(raise_scenario, raise_pos) or set()
-                )
-            else:
-                raise_range = set()
+        call_range: Set[str] = set()
+        raise_range: Set[str] = set()
+
+        if villain_act is None:
+            # Hero is first to act (RFI)
+            scenario, hero_pos, _ = self._scenario_for_actions([(hero_position, "raise")])
+            raise_range = self.chart.get_range_combos(scenario, hero_pos) or set()
+        elif villain_act == "raise":
+            sc_call, pos_call, _ = self._scenario_for_actions(pending + [(hero_position, "call")])
+            sc_raise, pos_raise, _ = self._scenario_for_actions(pending + [(hero_position, "3bet")])
+            call_range = self.chart.get_range_combos(sc_call, pos_call) or set()
+            raise_range = self.chart.get_range_combos(sc_raise, pos_raise) or set()
+        elif villain_act == "3bet":
+            ip = "IP" if _is_villain_ip(villain_pos, hero_position) else "OOP"
+            base = f"Cash, 100bb, 8-max, 3bet, {ip}"
+            call_range = (
+                self.chart.get_range_combos(base + ", call", _normalize_position(hero_position))
+                or set()
+            )
+            raise_range = (
+                self.chart.get_range_combos(base + ", 4bet", _normalize_position(hero_position))
+                or set()
+            )
+        elif villain_act == "4bet":
+            ip = "IP" if _is_villain_ip(villain_pos, hero_position) else "OOP"
+            base = f"Cash, 100bb, 8-max, 4bet, {ip}"
+            call_range = (
+                self.chart.get_range_combos(base + ", call", _normalize_position(hero_position))
+                or set()
+            )
+            raise_range = (
+                self.chart.get_range_combos(base + ", allin", _normalize_position(hero_position))
+                or set()
+            )
+        elif villain_act == "allin":
+            ip = "IP" if _is_villain_ip(villain_pos, hero_position) else "OOP"
+            scenario = f"Cash, 100bb, 8-max, allin, {ip}, call"
+            call_range = (
+                self.chart.get_range_combos(scenario, _normalize_position(hero_position))
+                or set()
+            )
 
         in_call = hand in call_range
         in_raise = hand in raise_range


### PR DESCRIPTION
## Summary
- add `scripts/solver_demo.py` to run TexasSolver demo
- include multiple bet sizes so actions aren't limited to check
- show a concise strategy summary if the solver output is present

## Testing
- `python scripts/solver_demo.py <<'EOF'
UTG raise, BTN call
BTN
QsJh2c
EOF`
- `python display_preflop_methods.py`
- `pytest -q` *(fails: pytest not found)*