### PR TITLE
Add solver demo and improve range parsing

### DIFF
--- a/scripts/solver_demo.py
+++ b/scripts/solver_demo.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Interactive demo linking preflop ranges with TexasSolver."""
+
+import json
+import os
+import subprocess
+import sys
+
+# Ensure the library is importable when running from the repo root
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src", "llm_poker_solver"))
+from preflop import PreflopLookup, expand_range
+
+
+def build_commands(hero_combos, villain_combos, board: str):
+    board_csv = ",".join(board[i : i + 2] for i in range(0, len(board), 2))
+    return [
+        "set_pot 100",
+        "set_effective_stack 200",
+        f"set_board {board_csv}",
+        f"set_range_ip {','.join(sorted(villain_combos))}",
+        f"set_range_oop {','.join(sorted(hero_combos))}",
+        "build_tree",
+        "start_solve",
+        "dump_result result.json",
+    ]
+
+
+def run_solver(cmds):
+    bin_path = os.path.join(
+        os.path.dirname(__file__), "..", "external", "TexasSolver", "build", "console_solver"
+    )
+    if not os.path.exists(bin_path):
+        print("TexasSolver binary not found; expected at", bin_path)
+        return None
+    proc = subprocess.Popen(
+        [bin_path], stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True
+    )
+    proc.stdin.write("\n".join(cmds) + "\n")
+    proc.stdin.flush()
+    out, _ = proc.communicate()
+    print("\n<<<START SOLVING>>>")
+    print(out)
+    try:
+        with open("result.json") as f:
+            return json.load(f)
+    except Exception as e:
+        print("Could not load result.json:", e)
+        return None
+
+
+def print_root_strategy(data):
+    if not data:
+        return
+    strat = data.get("strategy", {})
+    actions = strat.get("actions", [])
+    table = {}
+    for hand, probs in strat.get("strategy", {}).items():
+        for act, p in zip(actions, probs):
+            table[act] = table.get(act, 0.0) + p
+    if not table:
+        return
+    print("\n=== Root Strategy Summary ===")
+    total = sum(table.values())
+    for act in actions:
+        prob = table.get(act, 0.0) / total if total else 0.0
+        print(f"{act}: {prob:.2f}")
+
+
+def main():
+    action = input("Enter preflop action (e.g. 'UTG raise, BTN call'): ")
+    hero_pos = input("Enter hero position (default last actor): ").strip() or None
+    flop = input("Enter flop cards (e.g. 'QsJh2c'): ")
+
+    lookup = PreflopLookup()
+    ranges = lookup.get_ranges(action, hero_position=hero_pos)
+    hero_range = ranges.get("hero", "")
+    villain_range = ranges.get("villain", "")
+
+    print("\n=== Preflop ranges ===")
+    print("Hero:", hero_range)
+    print("Villain:", villain_range)
+
+    hero_combos = expand_range(hero_range) if hero_range else []
+    villain_combos = expand_range(villain_range) if villain_range else []
+
+    cmds = build_commands(hero_combos, villain_combos, flop)
+    print("\n=== TexasSolver commands ===")
+    for c in cmds:
+        print(c)
+
+    result = run_solver(cmds)
+    print_root_strategy(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/llm_poker_solver/preflop.py
+++ b/src/llm_poker_solver/preflop.py
@@ -93,13 +93,13 @@ def expand_range(desc: str) -> Set[str]:
     for part in [p.strip() for p in desc.split(",")]:
         if not part:
             continue
-        if "-" in part and "+" not in part:
-            start, end = part.split("-")
-            hands.update(_expand_between(start.strip(), end.strip()))
-        elif part.endswith("+"):
+        if part.endswith("+"):
             hands.update(_expand_plus(part[:-1]))
         elif part.endswith("-"):
             hands.update(_expand_minus(part[:-1]))
+        elif "-" in part and "+" not in part:
+            start, end = part.split("-")
+            hands.update(_expand_between(start.strip(), end.strip()))
         else:
             hands.add(part)
     return hands
@@ -143,7 +143,9 @@ def _expand_minus(base: str) -> List[str]:
     prefix = base[0]
     suited = base[2] == "s"
     end = RANK_TO_INDEX[base[1]]
-    return [f"{prefix}{RANKS[i]}{'s' if suited else 'o'}" for i in range(2, end + 1)]
+    return [
+        f"{prefix}{RANKS[i]}{'s' if suited else 'o'}" for i in range(0, end + 1)
+    ]
 
 
 def canonize_hand(hand: str) -> str:
@@ -302,7 +304,7 @@ class PreflopLookup:
             hero_position = acts[-1][0]
         hero_position = hero_position.upper()
 
-        # find last action from the hero in the sequence
+        # locate the most recent action from the hero
         hero_index = None
         for i in range(len(acts) - 1, -1, -1):
             if acts[i][0] == hero_position:
@@ -312,53 +314,58 @@ class PreflopLookup:
         if hero_index is None:
             raise ValueError("Hero position not found in action string")
 
-        last_index = len(acts) - 1
         hand = canonize_hand(hero_hand)
 
-        # Helper to compute a scenario with an additional hero action
-        def _scenario_with(act: str) -> Tuple[str, str]:
-            tmp = acts[: last_index + 1] + [(hero_position, act)]
-            scn, pos, _ = self._scenario_for_actions(tmp)
-            return scn, pos
-
-        if hero_index == last_index:
-            # hero was the last to act, so analyse that action directly
-            scenario, hero_pos, _ = self._scenario_for_actions(acts[: hero_index + 1])
-            call_range = self.chart.get_range_combos(scenario, hero_pos) or set()
-
-            next_act = {
-                "call": "3bet",
-                "raise": "3bet",
-                "3bet": "4bet",
-                "4bet": "allin",
-            }.get(acts[hero_index][1], None)
-
-            if next_act is not None:
-                alt_scenario, alt_pos = _scenario_with(next_act)
-                raise_range = (
-                    self.chart.get_range_combos(alt_scenario, alt_pos) or set()
-                )
-            else:
-                raise_range = set()
+        # Determine the sequence prior to the hero's decision
+        if hero_index == len(acts) - 1:
+            pending = acts[:hero_index]
         else:
-            # villain acted after hero; hero decision pending
-            villain_act = acts[last_index][1]
-            call_scenario, hero_pos = _scenario_with("call")
-            call_range = self.chart.get_range_combos(call_scenario, hero_pos) or set()
+            pending = acts[:]
 
-            next_act = {
-                "raise": "3bet",
-                "3bet": "4bet",
-                "4bet": "allin",
-            }.get(villain_act, None)
+        villain_act = pending[-1][1] if pending else None
+        villain_pos = pending[-1][0] if pending else None
 
-            if next_act is not None:
-                raise_scenario, raise_pos = _scenario_with(next_act)
-                raise_range = (
-                    self.chart.get_range_combos(raise_scenario, raise_pos) or set()
-                )
-            else:
-                raise_range = set()
+        call_range: Set[str] = set()
+        raise_range: Set[str] = set()
+
+        if villain_act is None:
+            # Hero is first to act (RFI)
+            scenario, hero_pos, _ = self._scenario_for_actions([(hero_position, "raise")])
+            raise_range = self.chart.get_range_combos(scenario, hero_pos) or set()
+        elif villain_act == "raise":
+            sc_call, pos_call, _ = self._scenario_for_actions(pending + [(hero_position, "call")])
+            sc_raise, pos_raise, _ = self._scenario_for_actions(pending + [(hero_position, "3bet")])
+            call_range = self.chart.get_range_combos(sc_call, pos_call) or set()
+            raise_range = self.chart.get_range_combos(sc_raise, pos_raise) or set()
+        elif villain_act == "3bet":
+            ip = "IP" if _is_villain_ip(villain_pos, hero_position) else "OOP"
+            base = f"Cash, 100bb, 8-max, 3bet, {ip}"
+            call_range = (
+                self.chart.get_range_combos(base + ", call", _normalize_position(hero_position))
+                or set()
+            )
+            raise_range = (
+                self.chart.get_range_combos(base + ", 4bet", _normalize_position(hero_position))
+                or set()
+            )
+        elif villain_act == "4bet":
+            ip = "IP" if _is_villain_ip(villain_pos, hero_position) else "OOP"
+            base = f"Cash, 100bb, 8-max, 4bet, {ip}"
+            call_range = (
+                self.chart.get_range_combos(base + ", call", _normalize_position(hero_position))
+                or set()
+            )
+            raise_range = (
+                self.chart.get_range_combos(base + ", allin", _normalize_position(hero_position))
+                or set()
+            )
+        elif villain_act == "allin":
+            ip = "IP" if _is_villain_ip(villain_pos, hero_position) else "OOP"
+            scenario = f"Cash, 100bb, 8-max, allin, {ip}, call"
+            call_range = (
+                self.chart.get_range_combos(scenario, _normalize_position(hero_position))
+                or set()
+            )
 
         in_call = hand in call_range
         in_raise = hand in raise_range


### PR DESCRIPTION
## Summary
- handle `-` range expansions correctly
- streamline recommendation logic before hero acts
- add `scripts/solver_demo.py` for TexasSolver demonstrations

## Testing
- `python display_preflop_methods.py`
- `python scripts/solver_demo.py <<'EOF'
UTG raise, BTN call
BTN
QsJh2c
EOF`
- `pytest -q` *(fails: command not found)*