### PR TITLE
Adjust default bet/raise sizes

### DIFF
--- a/scripts/advanced_solver_demo.py
+++ b/scripts/advanced_solver_demo.py
@@ -95,8 +95,13 @@ def main() -> None:
     use_suggested = get_user_input("Use suggested bet sizes? (y/n)", "y").lower() == "y"
     
     if not use_suggested:
-        ip_flop_sizes = get_user_input("Enter IP flop bet sizes (comma-separated percentages)", "50,75,100")
-        oop_flop_sizes = get_user_input("Enter OOP flop bet sizes (comma-separated percentages)", "50,75,100")
+        default_sizes = "25,33,50,66,75,100,150"
+        ip_flop_sizes = get_user_input(
+            "Enter IP flop bet sizes (comma-separated percentages)", default_sizes
+        )
+        oop_flop_sizes = get_user_input(
+            "Enter OOP flop bet sizes (comma-separated percentages)", default_sizes
+        )
         bet_sizes = {
             "ip_flop": [float(x.strip()) for x in ip_flop_sizes.split(",")],
             "oop_flop": [float(x.strip()) for x in oop_flop_sizes.split(",")]

--- a/src/llm_poker_solver/texas_solver.py
+++ b/src/llm_poker_solver/texas_solver.py
@@ -48,9 +48,9 @@ class SolverConfig:
         range_ip : str
             Hand range for in-position player
         bet_sizes : Dict[str, List[float]]
-            Betting sizes as % of pot for each street and position
+            Betting sizes as percentages of the pot for each street and position
         raise_sizes : Dict[str, List[float]]
-            Raise sizes as multipliers for each street and position
+            Raise sizes as percentages of the pot (e.g. ``250`` means 2.5x pot)
         donk_sizing : Dict[str, List[float]]
             Donk bet sizes as % of pot for each street
         """
@@ -64,21 +64,24 @@ class SolverConfig:
         
         # Default bet sizing if not provided
         self.bet_sizes = bet_sizes or {
-            'ip_flop': [50, 75, 100],
-            'ip_turn': [66, 100, 150],
-            'ip_river': [66, 100, 150],
-            'oop_flop': [50, 75, 100],
-            'oop_turn': [66, 100, 150],
-            'oop_river': [66, 100, 150],
+            # Default bet sizes are expressed as percentages of the pot
+            'ip_flop': [25, 33, 50, 66, 75, 100, 150],
+            'ip_turn': [50, 75, 100, 150],
+            'ip_river': [50, 75, 100, 150],
+            'oop_flop': [25, 33, 50, 66, 75, 100, 150],
+            'oop_turn': [50, 75, 100, 150],
+            'oop_river': [50, 75, 100, 150],
         }
-        
+
+        # Raise sizes are also percentages of the pot. Values like 250 mean
+        # a 2.5× raise size.
         self.raise_sizes = raise_sizes or {
-            'ip_flop': [2.5, 3.5],
-            'ip_turn': [2.5, 3.5],
-            'ip_river': [2.5, 3.5],
-            'oop_flop': [2.5, 3.5],
-            'oop_turn': [2.5, 3.5],
-            'oop_river': [2.5, 3.5],
+            'ip_flop': [250, 350],
+            'ip_turn': [250, 350],
+            'ip_river': [250, 350],
+            'oop_flop': [250, 350],
+            'oop_turn': [250, 350],
+            'oop_river': [250, 350],
         }
         
         self.donk_sizing = donk_sizing or {

--- a/src/llm_poker_solver/utils.py
+++ b/src/llm_poker_solver/utils.py
@@ -203,37 +203,13 @@ def suggest_bet_sizes(board_texture: Dict[str, Any]) -> Dict[str, List[float]]:
     Returns
     -------
     Dict[str, List[float]]
-        Suggested bet sizes for IP and OOP players
+        Suggested bet sizes for IP and OOP players. All values are
+        percentages of the pot.
     """
-    texture = board_texture.get("texture", "dry")
-    
-    # Default sizes
-    ip_sizes = {"ip_flop": [50, 75, 100]}
-    oop_sizes = {"oop_flop": [50, 75, 100]}
-    
-    # Adjust based on texture
-    if texture == "draw heavy":
-        # Larger bets on draw-heavy boards
-        ip_sizes["ip_flop"] = [75, 100, 150]
-        oop_sizes["oop_flop"] = [75, 100, 150]
-    elif texture in ["paired", "trips", "two pair"]:
-        # Polarized sizing on paired boards
-        ip_sizes["ip_flop"] = [33, 75, 150]
-        oop_sizes["oop_flop"] = [33, 75, 150]
-    elif texture == "dry":
-        # Smaller bets on dry boards
-        ip_sizes["ip_flop"] = [33, 50, 75]
-        oop_sizes["oop_flop"] = [33, 50, 75]
-    elif texture == "high card":
-        # Mixed sizes on high card boards
-        ip_sizes["ip_flop"] = [50, 75, 125]
-        oop_sizes["oop_flop"] = [50, 75, 125]
-    elif texture == "flush draw":
-        # Protection bets on flush draw boards
-        ip_sizes["ip_flop"] = [66, 100, 150]
-        oop_sizes["oop_flop"] = [66, 100, 150]
-    
-    return {**ip_sizes, **oop_sizes}
+    # Recommended bet sizes are the same for both players by default
+    # and expressed as percentages of the pot.
+    base_sizes = [25, 33, 50, 66, 75, 100, 150]
+    return {"ip_flop": base_sizes, "oop_flop": base_sizes}
 
 
 def generate_realistic_strategy(hand_value: float, board_texture: Dict[str, Any], 


### PR DESCRIPTION
## Summary
- update SolverConfig defaults to realistic percentages
- clarify raise sizing docs
- simplify bet-size recommendation helper
- use larger default list in advanced demo

## Testing
- `pytest -q`