### PR TITLE
Integrate new texas solver folder

### DIFF
--- a/scripts/advanced_solver_demo.py
+++ b/scripts/advanced_solver_demo.py
@@ -200,7 +200,7 @@ def main() -> None:
     print("This may take a few minutes depending on the complexity...")
     
     try:
-        output_file = os.path.join('solver_outputs', 'solver_results.json')
+        output_file = os.path.join('output', 'solver_results.json')
         result = solver.run_solver(output_file)
         print("Solver completed successfully!")
     except Exception as e:

--- a/src/llm_poker_solver/preflop.py
+++ b/src/llm_poker_solver/preflop.py
@@ -427,7 +427,10 @@ def compute_pot_and_effective_stack(
         elif act == "3bet":
             amount = 11 if pos in {"SB", "BB"} else 7.5
         elif act == "4bet":
-            ip = _is_villain_ip(last_raiser, pos)
+            # Determine if the raiser is in position relative to the last
+            # aggressor. In position 4bets are larger (25bb) while out of
+            # position 4bets are smaller (22bb).
+            ip = _is_villain_ip(pos, last_raiser)
             amount = 25 if ip else 22
         elif act in {"allin", "5bet"}:
             amount = stack_size

--- a/src/llm_poker_solver/texas_solver.py
+++ b/src/llm_poker_solver/texas_solver.py
@@ -28,7 +28,7 @@ class SolverConfig:
         bet_sizes: Dict[str, List[float]] = None,
         raise_sizes: Dict[str, List[float]] = None,
         donk_sizing: Dict[str, List[float]] = None,
-        allin_threshold: float = 0.8,
+        allin_threshold: float = 0.67,
     ):
         """Initialize solver configuration.
 
@@ -171,10 +171,9 @@ class TexasSolverBridge:
             Path to the TexasSolver binary
         """
         if solver_path is None:
-            # Default path relative to project root
-            solver_path = os.path.join(
-                'external', 'TexasSolver', 'build', 'console_solver'
-            )
+            # Default path relative to project root. The solver binary is
+            # shipped in the ``texas_solver`` directory at project root.
+            solver_path = os.path.join('texas_solver', 'console_solver')
         self.solver_path = solver_path
         self._result_path = None
         self._result_data = None
@@ -210,8 +209,8 @@ class TexasSolverBridge:
             raise FileNotFoundError(f"Solver binary not found at {self.solver_path}")
 
         root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        input_dir = os.path.join(root_dir, 'solver_inputs')
-        output_dir = os.path.join(root_dir, 'solver_outputs')
+        input_dir = os.path.join(root_dir, 'input')
+        output_dir = os.path.join(root_dir, 'output')
         os.makedirs(input_dir, exist_ok=True)
         os.makedirs(output_dir, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- refine pot calculation when 4‑betting and update solver binary path
- output solver files in `input/` and `output/` directories
- adjust default all-in threshold
- update demo script for new output folder

## Testing
- `pytest -q`