### PR TITLE
Improve betting suggestions and solver output

### DIFF
--- a/src/llm_poker_solver/texas_solver.py
+++ b/src/llm_poker_solver/texas_solver.py
@@ -10,6 +10,7 @@ import os
 import json
 import subprocess
 import tempfile
+import sys
 from typing import Dict, List, Tuple, Any, Optional, Set, Union
 
 
@@ -231,6 +232,11 @@ class TexasSolverBridge:
             text=True,
             capture_output=True
         )
+
+        if process.stdout:
+            print(process.stdout)
+        if process.stderr:
+            print(process.stderr, file=sys.stderr)
 
         if process.returncode != 0:
             raise RuntimeError(f"Solver failed: {process.stderr}")

--- a/src/llm_poker_solver/utils.py
+++ b/src/llm_poker_solver/utils.py
@@ -192,24 +192,31 @@ def analyze_board_texture(board: str) -> Dict[str, Any]:
 
 
 def suggest_bet_sizes(board_texture: Dict[str, Any]) -> Dict[str, List[float]]:
-    """
-    Suggest appropriate bet sizes based on board texture.
-    
+    """Suggest reasonable bet sizes based on board texture.
+
     Parameters
     ----------
     board_texture : Dict[str, Any]
-        Board texture analysis from analyze_board_texture
-    
+        Board texture analysis from :func:`analyze_board_texture`.
+
     Returns
     -------
     Dict[str, List[float]]
-        Suggested bet sizes for IP and OOP players. All values are
-        percentages of the pot.
+        Suggested bet sizes for IP and OOP players in percentages of the pot.
     """
-    # Recommended bet sizes are the same for both players by default
-    # and expressed as percentages of the pot.
-    base_sizes = [25, 33, 50, 66, 75, 100, 150]
-    return {"ip_flop": base_sizes, "oop_flop": base_sizes}
+
+    texture = board_texture.get("texture", "dry")
+
+    if texture in ["dry", "high card"]:
+        sizes = [25, 33, 50, 66]
+    elif texture in ["paired", "paired with flush draw", "trips", "two pair"]:
+        sizes = [50, 66, 75, 100]
+    elif texture in ["flush draw", "straight draw", "draw heavy"]:
+        sizes = [50, 66, 75, 100, 150]
+    else:
+        sizes = [25, 33, 50, 66, 75, 100, 150]
+
+    return {"ip_flop": sizes, "oop_flop": sizes}
 
 
 def generate_realistic_strategy(hand_value: float, board_texture: Dict[str, Any], 


### PR DESCRIPTION
## Summary
- tweak `suggest_bet_sizes` to use board texture for dynamic defaults
- display solver stdout/stderr when running TexasSolver

## Testing
- `pytest -q`